### PR TITLE
Implement basic container manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,8 @@ a default AI‑ready base image.
 The high level design is described in [docs/concept.md](docs/concept.md).
 See `AGENTS.md` for coding conventions and project structure.
 
+The project includes a minimal container manager able to discover
+containers on the local Docker host. The manager lists container names
+along with exposed ports as clickable links and provides start, stop,
+rebuild and remove actions.
+

--- a/docs/concept.md
+++ b/docs/concept.md
@@ -43,6 +43,11 @@ those repositories.
    - The application is built with Flask for rapid development, but
      this can be swapped out if needed.
 
+
+## Container Manager
+
+After containers are built, AIHost detects them from the Docker host and lists them in the interface. Each listed container shows its name and any exposed ports as clickable links. Users can start, stop, rebuild or remove containers directly from the list.
+
 ## Directory Layout
 
 - `src/` – Web server and service logic.

--- a/src/aihost/container_manager.py
+++ b/src/aihost/container_manager.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+import docker
+
+
+@dataclass
+class ContainerInfo:
+    """Representation of a Docker container."""
+
+    name: str
+    ports: List[str]
+
+
+def _client() -> docker.DockerClient:
+    """Return Docker client connected to the host."""
+
+    return docker.from_env()
+
+
+def list_containers() -> List[ContainerInfo]:
+    """Return all containers known to the Docker host."""
+
+    client = _client()
+    containers: List[ContainerInfo] = []
+    for container in client.containers.list(all=True):
+        ports = []
+        port_info = container.attrs.get("NetworkSettings", {}).get("Ports", {})
+        for container_port, mappings in port_info.items():
+            if not mappings:
+                continue
+            for mapping in mappings:
+                host_port = mapping.get("HostPort")
+                if host_port:
+                    ports.append(f"http://localhost:{host_port}")
+        containers.append(ContainerInfo(name=container.name, ports=ports))
+    return containers
+
+
+def start_container(name: str) -> None:
+    """Start a container by name."""
+
+    client = _client()
+    container = client.containers.get(name)
+    container.start()
+
+
+def stop_container(name: str) -> None:
+    """Stop a container by name."""
+
+    client = _client()
+    container = client.containers.get(name)
+    container.stop()
+
+
+def remove_container(name: str) -> None:
+    """Remove a container by name."""
+
+    client = _client()
+    container = client.containers.get(name)
+    container.remove(force=True)
+
+
+def rebuild_container(name: str, path: str) -> None:
+    """Rebuild the Docker image of a container.
+
+    The build context is provided by *path*.
+    """
+
+    client = _client()
+    client.images.build(path=path, tag=name, rm=True)

--- a/tests/test_container_manager.py
+++ b/tests/test_container_manager.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from aihost.container_manager import (  # noqa: E402
+    ContainerInfo,
+    list_containers,
+    remove_container,
+    rebuild_container,
+    start_container,
+    stop_container,
+)
+
+
+def _mock_client(container: MagicMock) -> MagicMock:
+    client = MagicMock()
+    client.containers.list.return_value = [container]
+    client.containers.get.return_value = container
+    return client
+
+
+def test_list_containers():
+    container = MagicMock()
+    container.name = "my_container"
+    container.attrs = {
+        "NetworkSettings": {"Ports": {"80/tcp": [{"HostPort": "8080"}]}}
+    }  # noqa: E501
+
+    client = _mock_client(container)
+    with patch(
+        "aihost.container_manager.docker.from_env",
+        return_value=client,
+    ):
+        result = list_containers()
+
+    assert result == [
+        ContainerInfo(name="my_container", ports=["http://localhost:8080"])
+    ]
+
+
+def test_start_stop_remove_rebuild():
+    container = MagicMock()
+    client = _mock_client(container)
+    with patch(
+        "aihost.container_manager.docker.from_env",
+        return_value=client,
+    ):
+        start_container("my_container")
+        stop_container("my_container")
+        remove_container("my_container")
+        rebuild_container("my_container", path=".")
+
+    container.start.assert_called_once()
+    container.stop.assert_called_once()
+    container.remove.assert_called_once_with(force=True)
+
+    client.images.build.assert_called_once_with(
+        path=".", tag="my_container", rm=True
+    )  # noqa: E501


### PR DESCRIPTION
## Summary
- add container manager module with list/start/stop/rebuild/remove helpers
- provide pytest-based tests for container manager behaviour using mocks
- document container manager concept and mention it in README

## Testing
- `flake8 src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cdbca22508333b670762ff6436527