### PR TITLE
Implement basic Flask web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,8 @@ containers on the local Docker host. The manager lists container names
 along with exposed ports as clickable links and provides start, stop,
 rebuild and remove actions.
 
+A small Flask based web interface exposes these features. The dashboard
+shows CPU and memory usage, counts running containers and links to their
+exposed ports. A repository registry allows adding or deleting
+repositories while the container view offers start, stop, rebuild and
+remove controls.

--- a/src/aihost/registry.py
+++ b/src/aihost/registry.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import List
+import json
+
+
+@dataclass
+class RepoInfo:
+    name: str
+    url: str
+    start_command: str
+
+
+REGISTRY_FILE = Path("data/registry.json")
+
+
+def _load() -> List[RepoInfo]:
+    if not REGISTRY_FILE.exists():
+        return []
+    data = json.loads(REGISTRY_FILE.read_text())
+    return [RepoInfo(**item) for item in data]
+
+
+def _save(repos: List[RepoInfo]) -> None:
+    REGISTRY_FILE.parent.mkdir(exist_ok=True)
+    REGISTRY_FILE.write_text(json.dumps([asdict(r) for r in repos], indent=2))
+
+
+def list_repos() -> List[RepoInfo]:
+    return _load()
+
+
+def add_repo(name: str, url: str, start_command: str) -> None:
+    repos = _load()
+    if any(r.name == name for r in repos):
+        raise ValueError(f"Repository '{name}' already exists")
+    repos.append(RepoInfo(name=name, url=url, start_command=start_command))
+    _save(repos)
+
+
+def delete_repo(name: str) -> None:
+    repos = [r for r in _load() if r.name != name]
+    _save(repos)

--- a/src/aihost/templates/dashboard.html
+++ b/src/aihost/templates/dashboard.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>AIHost Dashboard</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+</head>
+<body class="container py-4">
+  <h1 class="mb-4">AIHost Dashboard</h1>
+  <div class="row">
+    <div class="col-md-4">
+      <h2>Server Stats</h2>
+      <p>CPU Usage: {{ cpu_percent }}%</p>
+      <p>Memory Usage: {{ mem_percent }}%</p>
+      <p>Containers: {{ running }} / {{ total_containers }}</p>
+    </div>
+    <div class="col-md-8">
+      <h2>Containers</h2>
+      <table class="table">
+        <tr><th>Name</th><th>Ports</th><th>Actions</th></tr>
+        {% for c in containers %}
+        <tr>
+          <td>{{ c.name }}</td>
+          <td>
+            {% for p in c.ports %}
+              <a href="{{ p }}">{{ p }}</a>
+            {% endfor %}
+          </td>
+          <td>
+            <form method="post" action="{{ url_for('containers_action') }}">
+              <input type="hidden" name="name" value="{{ c.name }}" />
+              <button class="btn btn-sm btn-success" name="action" value="start">Start</button>
+              <button class="btn btn-sm btn-warning" name="action" value="stop">Stop</button>
+              <button class="btn btn-sm btn-info" name="action" value="rebuild">Rebuild</button>
+              <button class="btn btn-sm btn-danger" name="action" value="remove">Remove</button>
+            </form>
+          </td>
+        </tr>
+        {% endfor %}
+      </table>
+    </div>
+  </div>
+  <a href="{{ url_for('repos') }}">Manage Repositories</a>
+</body>
+</html>

--- a/src/aihost/templates/repos.html
+++ b/src/aihost/templates/repos.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Repository Registry</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+</head>
+<body class="container py-4">
+  <h1 class="mb-4">Repository Registry</h1>
+  <form class="mb-3" method="post">
+    <div class="mb-2">
+      <input class="form-control" name="name" placeholder="Name" required />
+    </div>
+    <div class="mb-2">
+      <input class="form-control" name="url" placeholder="Git Repository URL" required />
+    </div>
+    <div class="mb-2">
+      <input class="form-control" name="start_command" placeholder="Start Command" required />
+    </div>
+    <button class="btn btn-primary">Add Repo</button>
+  </form>
+  <table class="table">
+    <tr><th>Name</th><th>URL</th><th>Start Command</th><th></th></tr>
+    {% for r in repos %}
+    <tr>
+      <td>{{ r.name }}</td>
+      <td>{{ r.url }}</td>
+      <td>{{ r.start_command }}</td>
+      <td>
+        <form method="post">
+          <button class="btn btn-sm btn-danger" name="delete" value="{{ r.name }}">Delete</button>
+        </form>
+      </td>
+    </tr>
+    {% endfor %}
+  </table>
+  <a href="{{ url_for('dashboard') }}">Back to Dashboard</a>
+</body>
+</html>

--- a/src/aihost/web.py
+++ b/src/aihost/web.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from flask import Flask, render_template, request, redirect, url_for
+import psutil
+
+from .container_manager import (
+    list_containers,
+    start_container,
+    stop_container,
+    rebuild_container,
+    remove_container,
+)
+from .registry import list_repos, add_repo, delete_repo
+
+
+app = Flask(__name__)
+
+
+@app.route("/")
+def dashboard():
+    cpu_percent = psutil.cpu_percent()
+    mem_percent = psutil.virtual_memory().percent
+    containers = list_containers()
+    total_containers = len(containers)
+    running = sum(1 for c in containers if c.ports)
+    return render_template(
+        "dashboard.html",
+        cpu_percent=cpu_percent,
+        mem_percent=mem_percent,
+        containers=containers,
+        total_containers=total_containers,
+        running=running,
+    )
+
+
+@app.route("/repos", methods=["GET", "POST"])
+def repos():
+    if request.method == "POST":
+        if "delete" in request.form:
+            delete_repo(request.form["delete"])
+        else:
+            add_repo(
+                request.form["name"],
+                request.form["url"],
+                request.form["start_command"],
+            )
+        return redirect(url_for("repos"))
+    return render_template("repos.html", repos=list_repos())
+
+
+@app.route("/containers", methods=["POST"])
+def containers_action():
+    name = request.form["name"]
+    action = request.form["action"]
+    if action == "start":
+        start_container(name)
+    elif action == "stop":
+        stop_container(name)
+    elif action == "rebuild":
+        rebuild_container(name, path=".")
+    elif action == "remove":
+        remove_container(name)
+    return redirect(url_for("dashboard"))
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from pathlib import Path
+import pytest
+
+from aihost.registry import add_repo, delete_repo, list_repos, RepoInfo
+
+
+def test_registry(tmp_path: Path, monkeypatch):
+    file = tmp_path / "registry.json"
+    monkeypatch.setattr("aihost.registry.REGISTRY_FILE", file)
+
+    add_repo("repo1", "https://example.com", "run.sh")
+    repos = list_repos()
+    assert repos == [
+        RepoInfo(
+            name="repo1", url="https://example.com", start_command="run.sh"
+        )
+    ]
+
+    add_repo("repo2", "https://e.com", "start")
+    delete_repo("repo1")
+    repos = list_repos()
+    assert len(repos) == 1
+    assert repos[0].name == "repo2"
+
+
+def test_add_duplicate(tmp_path: Path, monkeypatch):
+    file = tmp_path / "registry.json"
+    monkeypatch.setattr("aihost.registry.REGISTRY_FILE", file)
+
+    add_repo("dup", "url", "cmd")
+    with pytest.raises(ValueError):
+        add_repo("dup", "url2", "cmd2")


### PR DESCRIPTION
## Summary
- implement repo registry module for storing repository data
- add a new Flask-based web interface with dashboard, repo, and container views
- create Jinja templates for dashboard and repository pages
- document the web interface in README
- add tests for the repository registry

## Testing
- `black src tests --line-length 79`
- `flake8 src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cdec68d58833381132010f3f85d5d