### PR TITLE
Add installer and management scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,11 @@ shows CPU and memory usage, counts running containers and links to their
 exposed ports. A repository registry allows adding or deleting
 repositories while the container view offers start, stop, rebuild and
 remove controls.
+
+## Installation and Usage
+
+Run `scripts/install.sh` to install AIHost into `/opt/AIHost` (or a custom path). The installer creates a Python virtual environment, installs dependencies and optionally registers a `systemd` service.
+
+Start the application with `scripts/start.sh`. The starter checks the repository for updates before launching the web server.
+
+To update an existing installation run `scripts/update.sh`. It performs `git pull`, installs new dependencies if needed and restarts the service when installed.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+flask
+psutil
+docker

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -e
+
+REPO_URL="https://github.com/example/AIHost.git"
+APP_DIR="/opt/AIHost"
+SERVICE_FILE="/etc/systemd/system/aihost.service"
+
+print_header() {
+    printf '\n\033[1;35m%s\033[0m\n' "============================="
+    printf '\033[1;35m%s\033[0m\n' "    AIHost Installer"
+    printf '\033[1;35m%s\033[0m\n\n' "============================="
+}
+
+print_header
+read -p "Install path [${APP_DIR}]: " input_dir
+APP_DIR=${input_dir:-$APP_DIR}
+read -p "Repository URL [${REPO_URL}]: " input_repo
+REPO_URL=${input_repo:-$REPO_URL}
+
+printf '\033[1;34mCloning repository...\033[0m\n'
+mkdir -p "$APP_DIR"
+if [ -d "$APP_DIR/.git" ]; then
+    echo "Directory already contains a git repository. Skipping clone."
+else
+    git clone "$REPO_URL" "$APP_DIR"
+fi
+
+printf '\033[1;34mSetting up virtual environment...\033[0m\n'
+python3 -m venv "$APP_DIR/venv"
+source "$APP_DIR/venv/bin/activate"
+
+if [ -f "$APP_DIR/requirements.txt" ]; then
+    printf '\033[1;34mInstalling requirements...\033[0m\n'
+    pip install -r "$APP_DIR/requirements.txt"
+fi
+
+deactivate
+
+read -p "Install systemd service for auto start? [y/N]: " yn
+if [[ $yn =~ ^[Yy]$ ]]; then
+    printf '\033[1;34mCreating service file...\033[0m\n'
+    sudo tee "$SERVICE_FILE" >/dev/null <<SERVICE
+[Unit]
+Description=AIHost Service
+After=network.target docker.service
+
+[Service]
+Type=simple
+WorkingDirectory=${APP_DIR}
+ExecStart=${APP_DIR}/venv/bin/python -m aihost.web
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+SERVICE
+    sudo systemctl daemon-reload
+    sudo systemctl enable aihost.service
+    echo "Service installed as aihost.service"
+fi
+
+printf '\n\033[1;32mInstallation complete!\033[0m\n'

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -e
+
+APP_DIR="/opt/AIHost"
+print_header() {
+    printf '\n\033[1;32m%s\033[0m\n' "========================="
+    printf '\033[1;32m%s\033[0m\n' "    AIHost Starter"
+    printf '\033[1;32m%s\033[0m\n\n' "========================="
+}
+
+print_header
+read -p "Application path [${APP_DIR}]: " input_dir
+APP_DIR=${input_dir:-$APP_DIR}
+
+cd "$APP_DIR"
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+printf '\033[1;34mChecking for updates...\033[0m\n'
+if git fetch origin; then
+    updates=$(git rev-list --count HEAD..origin/$BRANCH || echo 0)
+else
+    updates=0
+fi
+
+if [ "$updates" -gt 0 ]; then
+    printf '\033[1;33mUpdate available on branch %s (%s commits).\033[0m\n' "$BRANCH" "$updates"
+    read -p "Start anyway without updating? [y/N]: " reply
+    if [[ ! $reply =~ ^[Yy]$ ]]; then
+        echo "Start aborted. Run update.sh first."; exit 0
+    fi
+fi
+
+printf '\033[1;34mStarting AIHost...\033[0m\n'
+"$APP_DIR/venv/bin/python" -m aihost.web

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -e
+
+APP_DIR="/opt/AIHost"
+SERVICE_FILE="/etc/systemd/system/aihost.service"
+print_header() {
+    printf '\n\033[1;36m%s\033[0m\n' "========================="
+    printf '\033[1;36m%s\033[0m\n' "     AIHost Updater"
+    printf '\033[1;36m%s\033[0m\n\n' "========================="
+}
+
+print_header
+read -p "Application path [${APP_DIR}]: " input_dir
+APP_DIR=${input_dir:-$APP_DIR}
+
+cd "$APP_DIR"
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+printf '\033[1;34mPulling latest changes...\033[0m\n'
+old_rev=$(git rev-parse HEAD)
+if git pull --ff-only origin "$BRANCH"; then
+    new_rev=$(git rev-parse HEAD)
+else
+    echo "Update failed"; exit 1
+fi
+
+changed_req=$(git diff --name-only "$old_rev" "$new_rev" | grep requirements.txt || true)
+if [ -n "$changed_req" ]; then
+    printf '\033[1;34mRequirements changed. Installing...\033[0m\n'
+    "$APP_DIR/venv/bin/pip" install -r requirements.txt
+fi
+
+if [ -f "$SERVICE_FILE" ]; then
+    printf '\033[1;34mRestarting service...\033[0m\n'
+    sudo systemctl restart aihost.service
+fi
+
+printf '\n\033[1;32mUpdate complete!\033[0m\n'

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -14,7 +14,9 @@ def test_registry(tmp_path: Path, monkeypatch):
     repos = list_repos()
     assert repos == [
         RepoInfo(
-            name="repo1", url="https://example.com", start_command="run.sh"
+            name="repo1",
+            url="https://example.com",
+            start_command="run.sh",
         )
     ]
 


### PR DESCRIPTION
## Summary
- add installer, starter and updater shell scripts
- list runtime requirements
- describe installation and usage in README
- fix tests formatting

## Testing
- `black --check .`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687ce0f0721883339a5e236e62941990