### PR TITLE
Fix installer cloning mode

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -17,6 +17,21 @@ APP_DIR=${input_dir:-$APP_DIR}
 read -p "Repository URL [${REPO_URL}]: " input_repo
 REPO_URL=${input_repo:-$REPO_URL}
 
+# Ensure the repository URL uses HTTPS in case a git@ or ssh URL was provided
+convert_to_https() {
+    local url=$1
+    if [[ $url =~ ^git@([^:]+):(.+)$ ]]; then
+        printf "https://%s/%s" "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}"
+    elif [[ $url =~ ^ssh://git@([^/]+)/(.+)$ ]]; then
+        printf "https://%s/%s" "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}"
+    else
+        printf "%s" "$url"
+    fi
+}
+
+# Convert possible SSH style repo URLs to HTTPS
+REPO_URL=$(convert_to_https "$REPO_URL")
+
 printf '\033[1;34mCloning repository...\033[0m\n'
 mkdir -p "$APP_DIR"
 if [ -d "$APP_DIR/.git" ]; then

--- a/src/aihost/container_manager.py
+++ b/src/aihost/container_manager.py
@@ -34,7 +34,7 @@ def list_containers() -> List[ContainerInfo]:
             for mapping in mappings:
                 host_port = mapping.get("HostPort")
                 if host_port:
-                    ports.append(f"http://localhost:{host_port}")
+                    ports.append(f"http://localhost:{host_port}")  # noqa: E231
         containers.append(ContainerInfo(name=container.name, ports=ports))
     return containers
 


### PR DESCRIPTION
## Summary
- ensure installer uses HTTPS even if provided SSH URL
- silence flake8 false positive for F-string colon

## Testing
- `black --check .`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687ce2cc01188333a0fe29245809be7b