### PR TITLE
Fix AIHost startup module path

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,6 @@ remove controls.
 
 Run `scripts/install.sh` to install AIHost into `/opt/AIHost` (or a custom path). The installer creates a Python virtual environment, installs dependencies and optionally registers a `systemd` service.
 
-Start the application with `scripts/start.sh`. The starter checks the repository for updates before launching the web server.
+Start the application with `scripts/start.sh`. The starter checks the repository for updates before launching the web server and automatically sets `PYTHONPATH` so the `aihost` package can be found.
 
 To update an existing installation run `scripts/update.sh`. It performs `git pull`, installs new dependencies if needed and restarts the service when installed.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -63,6 +63,7 @@ After=network.target docker.service
 Type=simple
 WorkingDirectory=${APP_DIR}
 ExecStart=${APP_DIR}/venv/bin/python -m aihost.web
+Environment=PYTHONPATH=${APP_DIR}/src
 Restart=on-failure
 
 [Install]

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -30,4 +30,4 @@ if [ "$updates" -gt 0 ]; then
 fi
 
 printf '\033[1;34mStarting AIHost...\033[0m\n'
-"$APP_DIR/venv/bin/python" -m aihost.web
+PYTHONPATH="$APP_DIR/src" "$APP_DIR/venv/bin/python" -m aihost.web


### PR DESCRIPTION
## Summary
- ensure `src` is on `PYTHONPATH` when starting AIHost
- propagate this environment in the systemd service
- document the new behaviour in the README

## Testing
- `black .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cee7d90c48333bc77f144ece19c49