### PR TITLE
Bind Flask to 0.0.0.0 and remove path prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,6 @@ remove controls.
 
 Run `scripts/install.sh` to install AIHost into `/opt/AIHost` (or a custom path). The installer creates a Python virtual environment, installs dependencies and optionally registers a `systemd` service.
 
-Start the application with `scripts/start.sh`. The starter checks the repository for updates before launching the web server and automatically sets `PYTHONPATH` so the `aihost` package can be found.
+Start the application with `scripts/start.sh`. The starter checks the repository for updates before launching the web server and automatically sets `PYTHONPATH` so the `aihost` package can be found. It no longer prompts for the installation path and instead uses `/opt/AIHost` by default. The web server listens on all interfaces (`0.0.0.0`) so it can be reached from other hosts.
 
-To update an existing installation run `scripts/update.sh`. It performs `git pull`, installs new dependencies if needed and restarts the service when installed.
+To update an existing installation run `scripts/update.sh`. It performs `git pull`, installs new dependencies if needed and restarts the service when installed. Like the starter script, it assumes the default path `/opt/AIHost` without asking.

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -9,8 +9,6 @@ print_header() {
 }
 
 print_header
-read -p "Application path [${APP_DIR}]: " input_dir
-APP_DIR=${input_dir:-$APP_DIR}
 
 cd "$APP_DIR"
 BRANCH=$(git rev-parse --abbrev-ref HEAD)

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -10,8 +10,6 @@ print_header() {
 }
 
 print_header
-read -p "Application path [${APP_DIR}]: " input_dir
-APP_DIR=${input_dir:-$APP_DIR}
 
 cd "$APP_DIR"
 BRANCH=$(git rev-parse --abbrev-ref HEAD)

--- a/src/aihost/web.py
+++ b/src/aihost/web.py
@@ -64,4 +64,4 @@ def containers_action():
 
 
 if __name__ == "__main__":
-    app.run(debug=True)
+    app.run(host="0.0.0.0", debug=True)


### PR DESCRIPTION
## Summary
- launch Flask app on all interfaces
- drop application path prompts from management scripts
- clarify default path behaviour in README

## Testing
- `black --check src tests`
- `flake8 src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cefd0eba48333aff9e31941c49d70