### PR TITLE
Add CUDA-based repo builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Runtime directories
+data/
+compose/
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ containers on the local Docker host. The manager lists container names
 along with exposed ports as clickable links and provides start, stop,
 rebuild and remove actions.
 
+The `aihost.builder` module handles installation of repositories. It
+clones the specified Git repository, generates a Dockerfile based on the
+CUDA image `nvidia/cuda:12.1.1-base` and builds a Docker image ready for
+execution.
+
 A small Flask based web interface exposes these features. The dashboard
 shows CPU and memory usage, counts running containers and links to their
 exposed ports. A repository registry allows adding or deleting

--- a/docs/concept.md
+++ b/docs/concept.md
@@ -26,9 +26,11 @@ those repositories.
      container is built using a base image with GPU/AI support. This
      default base image is configurable but typically something like
      `nvidia/cuda:12.1.1-base` with Python included.
-   - The install process writes a simple Dockerfile using the base
-     image, copies the repo content, installs dependencies and sets the
-     default command to the provided start command.
+  - The install process writes a simple Dockerfile using the base
+    image, copies the repo content, installs dependencies and sets the
+    default command to the provided start command. This logic is
+    implemented in the `aihost.builder` module which builds the Docker
+    image after cloning the repository.
 
 4. **Container Management**
    - Docker Compose is used to orchestrate containers. Each registered

--- a/src/aihost/builder.py
+++ b/src/aihost/builder.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+
+import docker
+
+from .registry import RepoInfo
+
+
+DEFAULT_BASE_IMAGE = "nvidia/cuda:12.1.1-base"
+DATA_DIR = Path("data")
+
+
+def _client() -> docker.DockerClient:
+    return docker.from_env()
+
+
+def clone_repo(repo: RepoInfo, dest: Path) -> None:
+    if dest.exists():
+        return
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    subprocess.check_call(["git", "clone", repo.url, str(dest)])
+
+
+def write_dockerfile(
+    dest: Path, start_command: str, base_image: str = DEFAULT_BASE_IMAGE
+) -> None:
+    dockerfile = dest / "Dockerfile"
+    content = f"""FROM {base_image}
+WORKDIR /app
+COPY . /app
+RUN if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+CMD {start_command}
+"""
+    dockerfile.write_text(content)
+
+
+def build_image(name: str, path: Path) -> None:
+    client = _client()
+    client.images.build(path=str(path), tag=name, rm=True)
+
+
+def install_repo(repo: RepoInfo, base_image: str = DEFAULT_BASE_IMAGE) -> None:
+    dest = DATA_DIR / repo.name
+    clone_repo(repo, dest)
+    write_dockerfile(dest, repo.start_command, base_image)
+    build_image(repo.name, dest)

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from aihost.registry import RepoInfo  # noqa: E402
+from aihost import builder  # noqa: E402
+
+
+def test_install_repo(tmp_path: Path, monkeypatch):
+    repo = RepoInfo(
+        name="myrepo",
+        url="https://example.com/repo.git",
+        start_command="python app.py",
+    )
+    monkeypatch.setattr(builder, "DATA_DIR", tmp_path)
+
+    run_calls = []
+
+    def fake_call(cmd):
+        run_calls.append(cmd)
+        Path(cmd[-1]).mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setattr(builder.subprocess, "check_call", fake_call)
+
+    client = MagicMock()
+    monkeypatch.setattr(builder, "_client", lambda: client)
+
+    builder.install_repo(repo)
+
+    expected_dir = tmp_path / repo.name
+    assert run_calls[0] == ["git", "clone", repo.url, str(expected_dir)]
+
+    dockerfile = expected_dir / "Dockerfile"
+    assert dockerfile.exists()
+    text = dockerfile.read_text()
+    assert builder.DEFAULT_BASE_IMAGE in text
+    assert repo.start_command in text
+
+    client.images.build.assert_called_once_with(
+        path=str(expected_dir), tag=repo.name, rm=True
+    )

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,9 +1,16 @@
 from __future__ import annotations
 
 from pathlib import Path
-import pytest
+import sys
 
-from aihost.registry import add_repo, delete_repo, list_repos, RepoInfo
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+import pytest  # noqa: E402
+from aihost.registry import (  # noqa: E402
+    add_repo,
+    delete_repo,
+    list_repos,
+    RepoInfo,
+)  # noqa: E402
 
 
 def test_registry(tmp_path: Path, monkeypatch):


### PR DESCRIPTION
## Summary
- ignore runtime directories with `.gitignore`
- implement `aihost.builder` for cloning repos and building Docker images using a CUDA base image
- document the builder in README and concept docs
- add tests for the new builder module and adjust existing tests

## Testing
- `black --line-length 79 .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cf1deccd88333a4b1a09229ba2223