### PR TITLE
Add repo install button and dark theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,18 +11,21 @@ See `AGENTS.md` for coding conventions and project structure.
 The project includes a minimal container manager able to discover
 containers on the local Docker host. The manager lists container names
 along with exposed ports as clickable links and provides start, stop,
-rebuild and remove actions.
+rebuild and remove actions. The repository registry page now also offers
+an **Install** button which triggers the Docker builder to clone the
+repository and build its container image.
 
 The `aihost.builder` module handles installation of repositories. It
 clones the specified Git repository, generates a Dockerfile based on the
 CUDA image `nvidia/cuda:12.1.1-base` and builds a Docker image ready for
 execution.
 
-A small Flask based web interface exposes these features. The dashboard
-shows CPU and memory usage, counts running containers and links to their
-exposed ports. A repository registry allows adding or deleting
-repositories while the container view offers start, stop, rebuild and
-remove controls.
+A small Flask based web interface exposes these features. The interface
+uses a dark theme with rounded elements. The dashboard shows CPU and
+memory usage, counts running containers and links to their exposed
+ports. A repository registry allows adding or deleting repositories,
+installing them via the Docker builder and the container view offers
+start, stop, rebuild and remove controls.
 
 ## Installation and Usage
 

--- a/docs/concept.md
+++ b/docs/concept.md
@@ -30,7 +30,8 @@ those repositories.
     image, copies the repo content, installs dependencies and sets the
     default command to the provided start command. This logic is
     implemented in the `aihost.builder` module which builds the Docker
-    image after cloning the repository.
+    image after cloning the repository. The web interface exposes this
+    functionality with an **Install** button on the repository page.
 
 4. **Container Management**
    - Docker Compose is used to orchestrate containers. Each registered
@@ -39,9 +40,10 @@ those repositories.
      service. Stopping uses `docker compose stop` or `down` as needed.
 
 5. **Web Interface**
-   - The web interface is minimal. It allows registration, listing and
-     actions (install, start, stop, remove). Status is displayed based
-     on Docker state.
+   - The web interface is minimal and styled with a dark theme and
+     rounded elements. It allows registration, installation, listing and
+     actions (start, stop, remove). Status is displayed based on Docker
+     state.
    - The application is built with Flask for rapid development, but
      this can be swapped out if needed.
 

--- a/src/aihost/templates/dashboard.html
+++ b/src/aihost/templates/dashboard.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="utf-8" />
   <title>AIHost Dashboard</title>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.0/dist/darkly/bootstrap.min.css">
 </head>
-<body class="container py-4">
+<body class="container py-4 bg-dark text-light">
   <h1 class="mb-4">AIHost Dashboard</h1>
   <div class="row">
     <div class="col-md-4">
@@ -16,7 +16,7 @@
     </div>
     <div class="col-md-8">
       <h2>Containers</h2>
-      <table class="table">
+      <table class="table table-dark table-striped rounded">
         <tr><th>Name</th><th>Ports</th><th>Actions</th></tr>
         {% for c in containers %}
         <tr>
@@ -27,7 +27,7 @@
             {% endfor %}
           </td>
           <td>
-            <form method="post" action="{{ url_for('containers_action') }}">
+            <form class="d-inline-block rounded" method="post" action="{{ url_for('containers_action') }}">
               <input type="hidden" name="name" value="{{ c.name }}" />
               <button class="btn btn-sm btn-success" name="action" value="start">Start</button>
               <button class="btn btn-sm btn-warning" name="action" value="stop">Stop</button>

--- a/src/aihost/templates/repos.html
+++ b/src/aihost/templates/repos.html
@@ -3,11 +3,11 @@
 <head>
   <meta charset="utf-8" />
   <title>Repository Registry</title>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.0/dist/darkly/bootstrap.min.css">
 </head>
-<body class="container py-4">
+<body class="container py-4 bg-dark text-light">
   <h1 class="mb-4">Repository Registry</h1>
-  <form class="mb-3" method="post">
+  <form class="mb-3 rounded" method="post">
     <div class="mb-2">
       <input class="form-control" name="name" placeholder="Name" required />
     </div>
@@ -19,15 +19,20 @@
     </div>
     <button class="btn btn-primary">Add Repo</button>
   </form>
-  <table class="table">
-    <tr><th>Name</th><th>URL</th><th>Start Command</th><th></th></tr>
+  <table class="table table-dark table-striped rounded">
+    <tr><th>Name</th><th>URL</th><th>Start Command</th><th colspan="2"></th></tr>
     {% for r in repos %}
     <tr>
       <td>{{ r.name }}</td>
       <td>{{ r.url }}</td>
       <td>{{ r.start_command }}</td>
       <td>
-        <form method="post">
+        <form class="d-inline-block rounded" method="post">
+          <button class="btn btn-sm btn-secondary" name="install" value="{{ r.name }}">Install</button>
+        </form>
+      </td>
+      <td>
+        <form class="d-inline-block rounded" method="post">
           <button class="btn btn-sm btn-danger" name="delete" value="{{ r.name }}">Delete</button>
         </form>
       </td>

--- a/src/aihost/web.py
+++ b/src/aihost/web.py
@@ -11,6 +11,7 @@ from .container_manager import (
     remove_container,
 )
 from .registry import list_repos, add_repo, delete_repo
+from .builder import install_repo
 
 
 app = Flask(__name__)
@@ -38,6 +39,10 @@ def repos():
     if request.method == "POST":
         if "delete" in request.form:
             delete_repo(request.form["delete"])
+        elif "install" in request.form:
+            name = request.form["install"]
+            repo = next(r for r in list_repos() if r.name == name)
+            install_repo(repo)
         else:
             add_repo(
                 request.form["name"],


### PR DESCRIPTION
## Summary
- style dashboard and repo pages with a dark, rounded theme
- allow repositories to be installed via the web using `aihost.builder`
- document the new install feature and dark theme

## Testing
- `flake8 src tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687cf3aa5a688333bf4d8987dcc548c5