### PR TITLE
Update CUDA base image tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ repository and build its container image.
 
 The `aihost.builder` module handles installation of repositories. It
 clones the specified Git repository, generates a Dockerfile based on the
-CUDA image `nvidia/cuda:12.1.1-base` and builds a Docker image ready for
+CUDA image `nvidia/cuda:12.1.1-base-ubuntu20.04` and builds a Docker image ready for
 execution.
 
 A small Flask based web interface exposes these features. The interface

--- a/docs/concept.md
+++ b/docs/concept.md
@@ -24,8 +24,8 @@ those repositories.
      directory.
    - If the repository contains a `requirements.txt` file, the
      container is built using a base image with GPU/AI support. This
-     default base image is configurable but typically something like
-     `nvidia/cuda:12.1.1-base` with Python included.
+    default base image is configurable but typically something like
+    `nvidia/cuda:12.1.1-base-ubuntu20.04` with Python included.
   - The install process writes a simple Dockerfile using the base
     image, copies the repo content, installs dependencies and sets the
     default command to the provided start command. This logic is

--- a/src/aihost/builder.py
+++ b/src/aihost/builder.py
@@ -8,7 +8,11 @@ import docker
 from .registry import RepoInfo
 
 
-DEFAULT_BASE_IMAGE = "nvidia/cuda:12.1.1-base"
+# Use a specific CUDA base image tag that exists on Docker Hub.
+# The previous tag `12.1.1-base` is invalid and caused build failures
+# because the manifest is missing. The `ubuntu20.04` variant is
+# available and includes Python.
+DEFAULT_BASE_IMAGE = "nvidia/cuda:12.1.1-base-ubuntu20.04"
 DATA_DIR = Path("data")
 
 


### PR DESCRIPTION
## Summary
- fix builder base image tag so Docker build works
- document new CUDA tag in README and concept docs

## Testing
- `black -q src tests`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687cf5062f088333a4d4b965d8738aba