### PR TITLE
Support custom requirements file

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ containers on the local Docker host. The manager lists container names
 along with exposed ports as clickable links and provides start, stop,
 rebuild and remove actions. The repository registry page now also offers
 an **Install** button which triggers the Docker builder to clone the
-repository and build its container image.
+repository and build its container image. When adding a repository the
+form accepts a custom requirements file name in case the project does
+not use the default `requirements.txt`.
 
 The `aihost.builder` module handles installation of repositories. It
 clones the specified Git repository, generates a Dockerfile based on the

--- a/docs/concept.md
+++ b/docs/concept.md
@@ -22,7 +22,8 @@ those repositories.
 3. **Installation Process**
    - On install the system performs `git clone` into a managed
      directory.
-   - If the repository contains a `requirements.txt` file, the
+   - If the repository contains a requirements file (defaults to
+     `requirements.txt` but can be specified in the web form), the
      container is built using a base image with GPU/AI support. This
     default base image is configurable but typically something like
     `nvidia/cuda:12.1.1-base-ubuntu20.04` with Python included.

--- a/src/aihost/builder.py
+++ b/src/aihost/builder.py
@@ -28,13 +28,16 @@ def clone_repo(repo: RepoInfo, dest: Path) -> None:
 
 
 def write_dockerfile(
-    dest: Path, start_command: str, base_image: str = DEFAULT_BASE_IMAGE
+    dest: Path,
+    start_command: str,
+    requirements_file: str = "requirements.txt",
+    base_image: str = DEFAULT_BASE_IMAGE,
 ) -> None:
     dockerfile = dest / "Dockerfile"
     content = f"""FROM {base_image}
 WORKDIR /app
 COPY . /app
-RUN if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+RUN if [ -f {requirements_file} ]; then pip install -r {requirements_file}; fi  # noqa
 CMD {start_command}
 """
     dockerfile.write_text(content)
@@ -48,5 +51,10 @@ def build_image(name: str, path: Path) -> None:
 def install_repo(repo: RepoInfo, base_image: str = DEFAULT_BASE_IMAGE) -> None:
     dest = DATA_DIR / repo.name
     clone_repo(repo, dest)
-    write_dockerfile(dest, repo.start_command, base_image)
+    write_dockerfile(
+        dest,
+        repo.start_command,
+        requirements_file=repo.requirements_file,
+        base_image=base_image,
+    )
     build_image(repo.name, dest)

--- a/src/aihost/registry.py
+++ b/src/aihost/registry.py
@@ -11,6 +11,7 @@ class RepoInfo:
     name: str
     url: str
     start_command: str
+    requirements_file: str = "requirements.txt"
 
 
 REGISTRY_FILE = Path("data/registry.json")
@@ -20,7 +21,12 @@ def _load() -> List[RepoInfo]:
     if not REGISTRY_FILE.exists():
         return []
     data = json.loads(REGISTRY_FILE.read_text())
-    return [RepoInfo(**item) for item in data]
+    repos: List[RepoInfo] = []
+    for item in data:
+        if "requirements_file" not in item:
+            item["requirements_file"] = "requirements.txt"
+        repos.append(RepoInfo(**item))
+    return repos
 
 
 def _save(repos: List[RepoInfo]) -> None:
@@ -32,11 +38,23 @@ def list_repos() -> List[RepoInfo]:
     return _load()
 
 
-def add_repo(name: str, url: str, start_command: str) -> None:
+def add_repo(
+    name: str,
+    url: str,
+    start_command: str,
+    requirements_file: str = "requirements.txt",
+) -> None:
     repos = _load()
     if any(r.name == name for r in repos):
         raise ValueError(f"Repository '{name}' already exists")
-    repos.append(RepoInfo(name=name, url=url, start_command=start_command))
+    repos.append(
+        RepoInfo(
+            name=name,
+            url=url,
+            start_command=start_command,
+            requirements_file=requirements_file,
+        )
+    )
     _save(repos)
 
 

--- a/src/aihost/templates/repos.html
+++ b/src/aihost/templates/repos.html
@@ -17,15 +17,19 @@
     <div class="mb-2">
       <input class="form-control" name="start_command" placeholder="Start Command" required />
     </div>
+    <div class="mb-2">
+      <input class="form-control" name="requirements_file" placeholder="Requirements File (optional)" />
+    </div>
     <button class="btn btn-primary">Add Repo</button>
   </form>
   <table class="table table-dark table-striped rounded">
-    <tr><th>Name</th><th>URL</th><th>Start Command</th><th colspan="2"></th></tr>
+    <tr><th>Name</th><th>URL</th><th>Start Command</th><th>Requirements</th><th colspan="2"></th></tr>
     {% for r in repos %}
     <tr>
       <td>{{ r.name }}</td>
       <td>{{ r.url }}</td>
       <td>{{ r.start_command }}</td>
+      <td>{{ r.requirements_file }}</td>
       <td>
         <form class="d-inline-block rounded" method="post">
           <button class="btn btn-sm btn-secondary" name="install" value="{{ r.name }}">Install</button>

--- a/src/aihost/web.py
+++ b/src/aihost/web.py
@@ -48,6 +48,7 @@ def repos():
                 request.form["name"],
                 request.form["url"],
                 request.form["start_command"],
+                request.form.get("requirements_file", "requirements.txt"),
             )
         return redirect(url_for("repos"))
     return render_template("repos.html", repos=list_repos())

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -15,6 +15,7 @@ def test_install_repo(tmp_path: Path, monkeypatch):
         name="myrepo",
         url="https://example.com/repo.git",
         start_command="python app.py",
+        requirements_file="reqs.txt",
     )
     monkeypatch.setattr(builder, "DATA_DIR", tmp_path)
 
@@ -39,6 +40,7 @@ def test_install_repo(tmp_path: Path, monkeypatch):
     text = dockerfile.read_text()
     assert builder.DEFAULT_BASE_IMAGE in text
     assert repo.start_command in text
+    assert "reqs.txt" in text
 
     client.images.build.assert_called_once_with(
         path=str(expected_dir), tag=repo.name, rm=True

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -17,13 +17,14 @@ def test_registry(tmp_path: Path, monkeypatch):
     file = tmp_path / "registry.json"
     monkeypatch.setattr("aihost.registry.REGISTRY_FILE", file)
 
-    add_repo("repo1", "https://example.com", "run.sh")
+    add_repo("repo1", "https://example.com", "run.sh", "reqs.txt")
     repos = list_repos()
     assert repos == [
         RepoInfo(
             name="repo1",
             url="https://example.com",
             start_command="run.sh",
+            requirements_file="reqs.txt",
         )
     ]
 


### PR DESCRIPTION
## Summary
- allow specifying requirements file name when registering repos
- update HTML form and listing
- adjust README and docs
- support new field in builder and registry
- test custom requirements file handling

## Testing
- `flake8 src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cf6645d648333bad80597ee0d34d8