### PR TITLE
Fix Docker build failure and enforce lowercase tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ machine‑learning projects. Repositories are registered via a web
 interface, installed on demand and executed inside containers built from
 a default AI‑ready base image.
 
+**Note:** Docker image tags must be written in lowercase to satisfy the
+Docker daemon.
+
 The high level design is described in [docs/concept.md](docs/concept.md).
 See `AGENTS.md` for coding conventions and project structure.
 

--- a/docs/concept.md
+++ b/docs/concept.md
@@ -33,6 +33,8 @@ those repositories.
     implemented in the `aihost.builder` module which builds the Docker
     image after cloning the repository. The web interface exposes this
     functionality with an **Install** button on the repository page.
+  - Docker image tags are normalised to lowercase so builds succeed on
+    all Docker hosts.
 
 4. **Container Management**
    - Docker Compose is used to orchestrate containers. Each registered

--- a/src/aihost/container_manager.py
+++ b/src/aihost/container_manager.py
@@ -70,4 +70,4 @@ def rebuild_container(name: str, path: str) -> None:
     """
 
     client = _client()
-    client.images.build(path=path, tag=name, rm=True)
+    client.images.build(path=path, tag=name.lower(), rm=True)

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -12,7 +12,7 @@ from aihost import builder  # noqa: E402
 
 def test_install_repo(tmp_path: Path, monkeypatch):
     repo = RepoInfo(
-        name="myrepo",
+        name="MyRepo",
         url="https://example.com/repo.git",
         start_command="python app.py",
         requirements_file="reqs.txt",
@@ -41,7 +41,8 @@ def test_install_repo(tmp_path: Path, monkeypatch):
     assert builder.DEFAULT_BASE_IMAGE in text
     assert repo.start_command in text
     assert "reqs.txt" in text
+    assert "python3-pip" in text
 
     client.images.build.assert_called_once_with(
-        path=str(expected_dir), tag=repo.name, rm=True
+        path=str(expected_dir), tag="myrepo", rm=True
     )

--- a/tests/test_container_manager.py
+++ b/tests/test_container_manager.py
@@ -52,12 +52,12 @@ def test_start_stop_remove_rebuild():
         start_container("my_container")
         stop_container("my_container")
         remove_container("my_container")
-        rebuild_container("my_container", path=".")
+        rebuild_container("MyContainer", path=".")
 
     container.start.assert_called_once()
     container.stop.assert_called_once()
     container.remove.assert_called_once_with(force=True)
 
     client.images.build.assert_called_once_with(
-        path=".", tag="my_container", rm=True
+        path=".", tag="mycontainer", rm=True
     )  # noqa: E501


### PR DESCRIPTION
## Summary
- document lowercase requirement for Docker tags
- ensure Docker image tags are normalised to lowercase when building
- install python3-pip in generated Dockerfiles
- rebuild images using lowercase tags
- add tests for these changes

## Testing
- `black src tests`
- `flake8 src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cfbcc16b48333823149bfc5ff8579