### PR TITLE
Install build tools in Dockerfiles

### DIFF
--- a/src/aihost/builder.py
+++ b/src/aihost/builder.py
@@ -43,7 +43,12 @@ def write_dockerfile(
     content = f"""FROM {base_image}
 WORKDIR /app
 COPY . /app
-RUN apt-get update && apt-get install -y python3-pip && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y \
+    python3-pip \
+    python3-dev \
+    build-essential \
+    git \
+    && rm -rf /var/lib/apt/lists/*
 RUN if [ -f {requirements_file} ]; then pip3 install -r {requirements_file}; fi  # noqa
 CMD {start_command}
 """


### PR DESCRIPTION
## Summary
- install `python3-dev`, `build-essential`, and `git` during Docker build so packages requiring compilation can install

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cff65421083339b5b5b49e7379999