### PR TITLE
Improve container build feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,11 @@ form accepts a custom requirements file name in case the project does
 not use the default `requirements.txt`.
 
 The `aihost.builder` module handles installation of repositories. It
-clones the specified Git repository, generates a Dockerfile based on the
-CUDA image `nvidia/cuda:12.1.1-base-ubuntu20.04` and builds a Docker image ready for
-execution.
+clones the specified Git repository, generates a Dockerfile based on
+the CUDA image `nvidia/cuda:12.1.1-base-ubuntu20.04` and builds a Docker image
+ready for execution.
+Build logs are streamed to the console so progress is visible during
+installation or container rebuilds.
 
 A small Flask based web interface exposes these features. The interface
 uses a dark theme with rounded elements. The dashboard shows CPU and

--- a/src/aihost/container_manager.py
+++ b/src/aihost/container_manager.py
@@ -70,4 +70,18 @@ def rebuild_container(name: str, path: str) -> None:
     """
 
     client = _client()
-    client.images.build(path=path, tag=name.lower(), rm=True)
+    _, logs = client.images.build(
+        path=path,
+        tag=name.lower(),
+        rm=True,
+        decode=True,
+    )
+    for chunk in logs:
+        if "stream" in chunk:
+            line = chunk["stream"].strip()
+            if line:
+                print(line)
+        elif "status" in chunk:
+            print(chunk["status"].strip())
+        elif "error" in chunk:
+            print(chunk["error"].strip())

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -28,6 +28,7 @@ def test_install_repo(tmp_path: Path, monkeypatch):
     monkeypatch.setattr(builder.subprocess, "check_call", fake_call)
 
     client = MagicMock()
+    client.images.build.return_value = (MagicMock(), [])
     monkeypatch.setattr(builder, "_client", lambda: client)
 
     builder.install_repo(repo)
@@ -44,5 +45,5 @@ def test_install_repo(tmp_path: Path, monkeypatch):
     assert "python3-pip" in text
 
     client.images.build.assert_called_once_with(
-        path=str(expected_dir), tag="myrepo", rm=True
+        path=str(expected_dir), tag="myrepo", rm=True, decode=True
     )

--- a/tests/test_container_manager.py
+++ b/tests/test_container_manager.py
@@ -20,6 +20,7 @@ def _mock_client(container: MagicMock) -> MagicMock:
     client = MagicMock()
     client.containers.list.return_value = [container]
     client.containers.get.return_value = container
+    client.images.build.return_value = (MagicMock(), [])
     return client
 
 
@@ -59,5 +60,5 @@ def test_start_stop_remove_rebuild():
     container.remove.assert_called_once_with(force=True)
 
     client.images.build.assert_called_once_with(
-        path=".", tag="mycontainer", rm=True
+        path=".", tag="mycontainer", rm=True, decode=True
     )  # noqa: E501


### PR DESCRIPTION
## Summary
- show build progress when installing repositories or rebuilding containers
- update builder and container_manager tests for progress output
- document new progress logs in README

## Testing
- `flake8 src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d006b3d508333b487647b29b32915