### PR TITLE
Fix builder install error

### DIFF
--- a/src/aihost/builder.py
+++ b/src/aihost/builder.py
@@ -75,8 +75,11 @@ def build_image(name: str, path: Path) -> None:
     """Build the Docker image located at *path* and show progress."""
 
     client = _client()
+    # Docker already decodes build output into dictionaries, so disable
+    # additional decoding to avoid bytes/string mismatches in newer
+    # docker-py versions.
     _, logs = client.images.build(
-        path=str(path), tag=_normalize_tag(name), rm=True, decode=True
+        path=str(path), tag=_normalize_tag(name), rm=True, decode=False
     )
     _print_build_logs(logs)
 

--- a/src/aihost/container_manager.py
+++ b/src/aihost/container_manager.py
@@ -70,11 +70,13 @@ def rebuild_container(name: str, path: str) -> None:
     """
 
     client = _client()
+    # Disable docker-py decoding so that build output is handled
+    # consistently as dictionaries.
     _, logs = client.images.build(
         path=path,
         tag=name.lower(),
         rm=True,
-        decode=True,
+        decode=False,
     )
     for chunk in logs:
         if "stream" in chunk:

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -45,5 +45,5 @@ def test_install_repo(tmp_path: Path, monkeypatch):
     assert "python3-pip" in text
 
     client.images.build.assert_called_once_with(
-        path=str(expected_dir), tag="myrepo", rm=True, decode=True
+        path=str(expected_dir), tag="myrepo", rm=True, decode=False
     )

--- a/tests/test_container_manager.py
+++ b/tests/test_container_manager.py
@@ -60,5 +60,5 @@ def test_start_stop_remove_rebuild():
     container.remove.assert_called_once_with(force=True)
 
     client.images.build.assert_called_once_with(
-        path=".", tag="mycontainer", rm=True, decode=True
+        path=".", tag="mycontainer", rm=True, decode=False
     )  # noqa: E501


### PR DESCRIPTION
## Summary
- avoid duplicate JSON decoding when building Docker images
- update container rebuild to match
- adjust tests for new behaviour

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d023d1b548333b2d9ebfd311c58f9