### PR TITLE
Add GPU stats to dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ may include volume directories referenced by the compose file.
 
 A small Flask based web interface exposes these features. The interface
 uses a dark theme with rounded elements. The dashboard shows CPU and
-memory usage, counts running containers and links to their exposed
+memory usage and, when available, GPU statistics such as VRAM
+utilization. It also counts running containers and links to their exposed
 ports. Detected applications are listed with start, stop, rebuild and
 remove controls executed through Docker Compose.
 

--- a/docs/concept.md
+++ b/docs/concept.md
@@ -27,8 +27,8 @@ corresponding application folder.
 
 3. **Web Interface**
    - Implemented with Flask and styled using a dark theme.
-   - Shows CPU and memory usage alongside the list of containers and
-     available applications.
+  - Shows CPU and memory usage alongside GPU statistics when
+    available, plus the list of containers and available applications.
 
 ## Directory Layout
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 flask
 psutil
 docker
+nvidia-ml-py3

--- a/src/aihost/gpu.py
+++ b/src/aihost/gpu.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from typing import Optional, Dict
+
+
+def get_gpu_stats() -> Optional[Dict[str, int | str]]:
+    """Return GPU statistics if available.
+
+    The function queries the first available NVIDIA GPU using ``pynvml``.
+    Results are returned in megabytes. If no GPU or NVML library is
+    present, ``None`` is returned.
+    """
+
+    try:
+        import pynvml  # type: ignore
+    except Exception:
+        return None
+
+    try:
+        pynvml.nvmlInit()
+        count = pynvml.nvmlDeviceGetCount()
+        if count < 1:
+            return None
+        handle = pynvml.nvmlDeviceGetHandleByIndex(0)
+        name = pynvml.nvmlDeviceGetName(handle).decode()
+        mem = pynvml.nvmlDeviceGetMemoryInfo(handle)
+        total_mb = mem.total // (1024 * 1024)
+        used_mb = mem.used // (1024 * 1024)
+        percent = int(used_mb / total_mb * 100) if total_mb else 0
+        return {
+            "name": name,
+            "memory_total": total_mb,
+            "memory_used": used_mb,
+            "memory_percent": percent,
+        }
+    except Exception:
+        return None
+    finally:
+        try:
+            pynvml.nvmlShutdown()
+        except Exception:
+            pass

--- a/src/aihost/templates/dashboard.html
+++ b/src/aihost/templates/dashboard.html
@@ -21,6 +21,12 @@
       <h2>Server Stats</h2>
       <p>CPU Usage: {{ cpu_percent }}%</p>
       <p>Memory Usage: {{ mem_percent }}%</p>
+      {% if gpu %}
+      <p>GPU: {{ gpu.name }}</p>
+      <p>VRAM: {{ gpu.memory_used }}MB / {{ gpu.memory_total }}MB ({{ gpu.memory_percent }}%)</p>
+      {% else %}
+      <p>GPU: N/A</p>
+      {% endif %}
       <p>Containers: {{ running }} / {{ total_containers }}</p>
     </div>
     <div class="col-md-8">

--- a/src/aihost/web.py
+++ b/src/aihost/web.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from flask import Flask, render_template, request, redirect, url_for
 import psutil
 
+from .gpu import get_gpu_stats
+
 from .container_manager import (
     list_containers,
     list_apps,
@@ -19,6 +21,7 @@ app = Flask(__name__)
 def dashboard():
     cpu_percent = psutil.cpu_percent()
     mem_percent = psutil.virtual_memory().percent
+    gpu = get_gpu_stats()
     containers = list_containers()
     apps = list_apps()
     total_containers = len(containers)
@@ -27,6 +30,7 @@ def dashboard():
         "dashboard.html",
         cpu_percent=cpu_percent,
         mem_percent=mem_percent,
+        gpu=gpu,
         containers=containers,
         apps=apps,
         total_containers=total_containers,

--- a/tests/test_gpu.py
+++ b/tests/test_gpu.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from aihost.gpu import get_gpu_stats  # noqa: E402
+
+
+def test_get_gpu_stats_no_library(monkeypatch):
+    monkeypatch.setitem(sys.modules, "pynvml", None)
+    assert get_gpu_stats() is None
+
+
+def test_get_gpu_stats_success(monkeypatch):
+    mem = types.SimpleNamespace(total=4 * 1024 * 1024, used=2 * 1024 * 1024)
+
+    def fake_nvmlInit():
+        pass
+
+    def fake_nvmlShutdown():
+        pass
+
+    def fake_nvmlDeviceGetCount():
+        return 1
+
+    def fake_nvmlDeviceGetHandleByIndex(index):
+        return "h"
+
+    def fake_nvmlDeviceGetName(handle):
+        return b"FakeGPU"
+
+    def fake_nvmlDeviceGetMemoryInfo(handle):
+        return mem
+
+    fake_module = types.SimpleNamespace(
+        nvmlInit=fake_nvmlInit,
+        nvmlShutdown=fake_nvmlShutdown,
+        nvmlDeviceGetCount=fake_nvmlDeviceGetCount,
+        nvmlDeviceGetHandleByIndex=fake_nvmlDeviceGetHandleByIndex,
+        nvmlDeviceGetName=fake_nvmlDeviceGetName,
+        nvmlDeviceGetMemoryInfo=fake_nvmlDeviceGetMemoryInfo,
+    )
+    monkeypatch.setitem(sys.modules, "pynvml", fake_module)
+
+    stats = get_gpu_stats()
+    assert stats == {
+        "name": "FakeGPU",
+        "memory_total": 4,
+        "memory_used": 2,
+        "memory_percent": 50,
+    }


### PR DESCRIPTION
## Summary
- display GPU statistics on dashboard when available
- implement `get_gpu_stats` helper with NVML
- expose GPU metrics in Flask app and template
- test GPU helper
- document GPU support in README and concept docs
- require `nvidia-ml-py3` dependency

## Testing
- `black src tests`
- `flake8 src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e0cfb5c6c833388356e7f40d9003b