### PR TITLE
Enhance install script apt checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ remove controls executed through Docker Compose.
 
 ## Installation and Usage
 
-Run `scripts/install.sh` to install AIHost into `/opt/AIHost` (or a custom path). The installer creates a Python virtual environment, installs dependencies and optionally registers a `systemd` service.
+Run `scripts/install.sh` to install AIHost into `/opt/AIHost` (or a custom path). The installer checks for required apt packages such as `python3-venv`, creates a Python virtual environment, installs dependencies and optionally registers a `systemd` service.
 
 Start the application with `scripts/start.sh`. The starter checks the repository for updates before launching the web server and automatically sets `PYTHONPATH` so the `aihost` package can be found. It no longer prompts for the installation path and instead uses `/opt/AIHost` by default. The web server listens on all interfaces (`0.0.0.0`) so it can be reached from other hosts.
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -17,6 +17,26 @@ APP_DIR=${input_dir:-$APP_DIR}
 read -p "Repository URL [${REPO_URL}]: " input_repo
 REPO_URL=${input_repo:-$REPO_URL}
 
+# Check and install required apt packages
+check_apt_package() {
+    local pkg=$1
+    if ! dpkg -s "$pkg" >/dev/null 2>&1; then
+        printf '\033[1;34mInstalling %s...\033[0m\n' "$pkg"
+        sudo apt-get update
+        sudo apt-get install -y "$pkg"
+    fi
+}
+
+ensure_system_dependencies() {
+    if command -v apt-get >/dev/null 2>&1; then
+        local ver
+        ver=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
+        check_apt_package "python${ver}-venv"
+    fi
+}
+
+ensure_system_dependencies
+
 # Ensure the repository URL uses HTTPS in case a git@ or ssh URL was provided
 convert_to_https() {
     local url=$1


### PR DESCRIPTION
## Summary
- ensure the install script installs necessary apt packages before creating the venv
- mention automatic apt package installation in README

## Testing
- `black .`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687e0fd862a88333b797e929f29e1527