### PR TITLE
Add async app install with log view

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ memory usage and, when available, GPU statistics such as VRAM
 utilization. It also counts running containers and links to their exposed
 ports. Detected apps are presented in the AppStore with install and
 deinstall controls, while running containers offer start, stop and
-rebuild buttons.
+rebuild buttons. Each app entry also includes a **Log/Status** link that opens
+the most recent container logs in a separate window.
 
 ## Installation and Usage
 

--- a/docs/concept.md
+++ b/docs/concept.md
@@ -28,10 +28,12 @@ corresponding application folder.
      daemon and displayed on the dashboard.
 
 3. **Web Interface**
-   - Implemented with Flask and styled using a dark theme.
+  - Implemented with Flask and styled using a dark theme.
   - Shows CPU and memory usage alongside GPU statistics when
     available, plus the list of containers and available apps. The
     applications are presented in an **AppStore** tab.
+  - Each app entry provides a *Log/Status* button that opens the recent
+    container logs in a new window.
 
 ## Directory Layout
 

--- a/src/aihost/templates/dashboard.html
+++ b/src/aihost/templates/dashboard.html
@@ -75,6 +75,7 @@
               <button class="btn btn-sm btn-success" name="action" value="install">Install</button>
               <button class="btn btn-sm btn-danger" name="action" value="deinstall">Deinstall</button>
             </form>
+            <a class="btn btn-sm btn-secondary" href="{{ url_for('app_logs', app=a) }}" target="_blank">Log/Status</a>
           </td>
         </tr>
         {% endfor %}

--- a/src/aihost/templates/logs.html
+++ b/src/aihost/templates/logs.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Logs - {{ app }}</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.0/dist/darkly/bootstrap.min.css">
+</head>
+<body class="container py-4 bg-dark text-light">
+  <h1>Logs for {{ app }}</h1>
+  <pre class="bg-dark text-light" style="white-space: pre-wrap">{{ logs }}</pre>
+</body>
+</html>

--- a/src/aihost/web.py
+++ b/src/aihost/web.py
@@ -11,8 +11,9 @@ from .container_manager import (
     start_container,
     stop_container,
     rebuild_container,
-    install_app,
-    deinstall_app,
+    install_app_async,
+    deinstall_app_async,
+    get_app_logs,
 )
 
 app = Flask(__name__)
@@ -59,10 +60,18 @@ def apps_action():
     name = request.form["name"]
     action = request.form["action"]
     if action == "install":
-        install_app(name)
+        install_app_async(name)
     elif action == "deinstall":
-        deinstall_app(name)
+        deinstall_app_async(name)
     return redirect(url_for("dashboard"))
+
+
+@app.route("/logs/<app>")
+def app_logs(app: str):
+    """Display recent logs for *app*."""
+
+    logs = get_app_logs(app)
+    return render_template("logs.html", app=app, logs=logs)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `LOGS_DIR` constant and functions for async compose commands
- add log retrieval via `get_app_logs`
- update Flask app to use new async actions
- provide `/logs/<app>` route and template
- link Log/Status button in dashboard
- document new feature and extend tests

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e2f7228c08333b399242e369be2d0